### PR TITLE
Corrected issue with Sketch 41 where plugin was failing to get hex color

### DIFF
--- a/ReplaceColour.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/ReplaceColour.sketchplugin/Contents/Sketch/script.cocoascript
@@ -221,7 +221,7 @@ var onRun = function(context) {
 			}
 		}
 
-		return colour;
+		return colour.immutableModelObject();
 	}
 
 	/**


### PR DESCRIPTION
Not sure if this is sufficiently robust. Does it work in earlier versions of Sketch? Is there a more elegant way to fix it?

Related to #10 